### PR TITLE
Remove 20H2 build pipeline

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -54,66 +54,6 @@ trigger:
 
 ---
 kind: pipeline
-name: windows-20H2
-platform:
-  os: windows
-  arch: amd64
-  version: 20H2
-# remove this and use upstream images when https://github.com/drone/drone-git/pull/25 is merged
-clone:
-  disable: true
-steps:
-  - name: clone
-    image: rancher/drone-images:git-20H2
-    settings:
-      depth: 20
-  - name: build
-    pull: always
-    image: rancher/dapper:v0.5.8
-    commands:
-      - "docker build -f Dockerfile.windows --build-arg WINDOWS_VERSION=20H2 ."
-    volumes:
-      - name: docker_pipe
-        path: \\\\.\\pipe\\docker_engine
-    when:
-      event:
-        - push
-        - pull_request
-        - tag
-  - name: docker-publish
-    image: rancher/drone-images:docker-20H2
-    settings:
-      build_args:
-        - "WINDOWS_VERSION=20H2"
-        - "ARCH=amd64"
-        - "VERSION=${DRONE_TAG}"
-      custom_dns: 1.1.1.1
-      dockerfile: Dockerfile.windows
-      username:
-        from_secret: docker_username
-      password:
-        from_secret: docker_password
-      repo: "rancher/fluent-bit"
-      tag: "${DRONE_TAG}-windows-20H2"
-    volumes:
-      - name: docker_pipe
-        path: \\\\.\\pipe\\docker_engine
-    when:
-      event:
-        - tag
-      ref:
-        - refs/heads/master
-        - refs/tags/*
-volumes:
-  - name: docker_pipe
-    host:
-      path: \\\\.\\pipe\\docker_engine
-trigger:
-  event:
-    exclude:
-      - promote
----
-kind: pipeline
 name: windows-ltsc2022
 platform:
   os: windows
@@ -200,5 +140,4 @@ trigger:
         - promote
 depends_on:
   - windows-1809
-  - windows-20H2
   - windows-ltsc2022

--- a/manifest.tmpl
+++ b/manifest.tmpl
@@ -7,12 +7,6 @@ manifests:
       os: windows
       version: 1809
   -
-    image: rancher/fluent-bit:{{build.tag}}-windows-20H2
-    platform:
-      architecture: amd64
-      os: windows
-      version: 20H2
-  -
     image: rancher/fluent-bit:{{build.tag}}-windows-ltsc2022
     platform:
       architecture: amd64


### PR DESCRIPTION
### Issue: https://github.com/rancher/windows/issues/222

While preparing to cut a new version of `rancher/fluent-bit` I noticed that we still have a build pipeline for 20H2, which we no longer support.

I also noticed an inconsistency between the readme and the current content of `Dockerfile.windows` and `config.json`. Running `make` will actually downgrade the fluent-bit version included in `Dockerfile.windows`, as the version included in `config.json` is set to `v1.7.4`, whereas the desired version is `v1.9.8`. The current `Dockerfile.windows` also does not match the [upstream Dockerfile for `v1.9.8`](https://github.com/fluent/fluent-bit/blob/1.9.8-pack-fixes/dockerfiles/Dockerfile.windows), though I'm not sure if that is an issue or not. 

As a follow up we should determine if we need to update the `config.json` and `Dockerfile.windows` to match what is included in fluent-bit `v1.9.8`, or if we can continue with what we currently have. If we decide to update the Dockerfile, we should test charts which depend on this image to ensure we haven't broken anything. 