### PR TITLE
Fix 1809 pipeline

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -5,6 +5,10 @@ platform:
   os: windows
   arch: amd64
   version: 1809
+# Currently have to define "depth" as otherwise clone fails at
+# https://github.com/drone/drone-git/blob/39d233b3d9eccc68e66508a06a725a2567f33143/windows/clone-tag.ps1#L12
+clone:
+  depth: 20
 steps:
   - name: build
     pull: always


### PR DESCRIPTION
Relates to: https://github.com/rancher/windows/issues/222

Seems like this repo is hitting similar errors as wins, this PR mimics the changes in https://github.com/rancher/wins/pull/153 to fix the tag pipeline. The errors in [#9](https://drone-publish.rancher.io/rancher/fluent-bit-package/45/1/1) are exactly the same error seen in the rancher/wins repo ([#186](https://drone-publish.rancher.io/rancher/wins/186/1/1)) after a tag, before the change was merged.

I haven't updated the 2022 pipeline since there is already a depth of 20 set on the `clone` step
```yaml
clone:
  disable: true
steps:
  - name: clone
    image: rancher/drone-images:git-amd64-ltsc2022
    settings:
      depth: 20
```