### PR TITLE
Bump version to 2.2.0, update URL for downloading fluent-bit

### DIFF
--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -8,7 +8,7 @@ ARG WINDOWS_VERSION=ltsc2019
 FROM mcr.microsoft.com/windows/servercore:$WINDOWS_VERSION as builder
 
 # The FLUENTBIT_VERSION ARG must be after the FROM instruction
-ARG FLUENTBIT_VERSION=1.8.9
+ARG FLUENTBIT_VERSION=2.2.0
 ARG IMAGE_CREATE_DATE
 ARG IMAGE_SOURCE_REVISION
 
@@ -42,7 +42,7 @@ WORKDIR /local
 #
 RUN Write-Host ('Installing Fluent Bit'); `
     $majorminor = ([Version]::Parse("$env:FLUENTBIT_VERSION")).toString(2); `
-    Invoke-WebRequest -Uri "https://fluentbit.io/releases/$($majorminor)/td-agent-bit-$($env:FLUENTBIT_VERSION)-win64.zip" -OutFile td-agent-bit.zip; `
+    Invoke-WebRequest -Uri "https://fluentbit.io/releases/$($majorminor)/fluent-bit-$($env:FLUENTBIT_VERSION)-win64.zip" -OutFile td-agent-bit.zip; `
     Expand-Archive -Path td-agent-bit.zip -Destination /local/fluent-bit; `
     Move-Item -Path /local/fluent-bit/*/* -Destination /fluent-bit/;
 


### PR DESCRIPTION
The rancher logging chart has been bumped to 4.4.0 for 2.8 and 2.9. Windows support was broken as those charts are still using 1.8.9 of fluent-bit. In order to restore windows support we need to use a 2.2.x version of fluent-bit agent. I've opted to use the same version as the linux agent, 2.2.0. 

I did a quick test of this updated image when vendored into the logging chart and saw it successfully deploy onto a windows cluster. I also confirmed that a simple file output worked as expected. 

The name of the release artifact has changed since 1.8.9, so the dockerfile has been updated to point to the correct URL 

The following windows related changes have occurred since version 1.8.9 and 2.2.0. From what I can tell, no functionality has been removed, all changes related to the windows exporter metrics are either small bug fixes or new metrics.

+ https://github.com/fluent/fluent-bit/commit/8e6a5be95eebb8f687a9374c1f012231e5beeae3 windows: enable ECS filter 
+ in_windows_exporter_metrics: Fill the empty string when l2/l3 cache is not defined case
+ build: config_format: Support YAML config format on Windows package by 
+ in_windows_exporter_metrics: Fix wrong metrics type of free megabytes
+ in_windows_exporter_metrics: Add service metrics support by 
+ in_windows_exporter_metrics: Implement WMI based process metrics by 
+ in_windows_exporter_metrics: Implement WMI based memory and paging_file metrics by 
+ workflows: windows: Use vcpkg to install dependencies 
+ workflows: windows: Implement cache mechanism for source packages of vcpkg by 
+ workflow: windows: Make more rigid handling for caches 
+ in_calyptia_fleet: windows support
+ http_server: v2: reload: windows: Enable hot reloading by 
+ flb_utils: add code to get the machine-id on windows machines. 
+ bin: windows: Restore Ctrl-C behavior on windows
+ config_format: yaml: windows: Handle directory separator for include directive on yaml config correctly on windows
+ windows: build docs and tweaks 
+ workflows: merge multiple Windows uploads together
+ dockerfile: windows: Link OpenSSL libraries correctly
+ workflows: windows: Use concrete option on Invoke-WebRequest
+ workflows: windows: Add chain workflow for windows unit testing